### PR TITLE
Treat all non-hash enumerable objects like arrays

### DIFF
--- a/lib/blueprinter/helpers/type_helpers.rb
+++ b/lib/blueprinter/helpers/type_helpers.rb
@@ -3,13 +3,10 @@
 module Blueprinter
   module TypeHelpers
     private
-    def active_record_relation?(object)
-      !!(defined?(ActiveRecord::Relation) &&
-        object.is_a?(ActiveRecord::Relation))
-    end
-
     def array_like?(object)
-      object.is_a?(Array) || active_record_relation?(object)
+      return false if object.is_a?(Hash)
+
+      object.is_a?(Array) || object.is_a?(Enumerable)
     end
   end
 end

--- a/spec/integrations/base_spec.rb
+++ b/spec/integrations/base_spec.rb
@@ -394,19 +394,20 @@ describe '::Base' do
         end
       end
 
-      context 'Given a collection of objects' do
+      context 'Given a non-activerecord-relation collection of objects' do
         let(:blueprint) do
           Class.new(Blueprinter::Base) do
             identifier :id
             fields :make
           end
         end
-        let(:obj) { Vehicle.all }
         let(:vehicle1) { create(:vehicle) }
         let(:vehicle2) { create(:vehicle, make: 'Mediocre Car') }
         let(:vehicle3) { create(:vehicle, make: 'Terrible Car') }
+        let(:vehicles) { [vehicle1, vehicle2, vehicle3] }
+        let(:obj) { Set.new(vehicles) }
         let(:result) do
-          vehicles_json = [vehicle1, vehicle2, vehicle3].map do |vehicle|
+          vehicles_json = vehicles.map do |vehicle|
             "{\"id\":#{vehicle.id},\"make\":\"#{vehicle.make}\"}"
           end.join(',')
           "[#{vehicles_json}]"

--- a/spec/integrations/base_spec.rb
+++ b/spec/integrations/base_spec.rb
@@ -56,6 +56,16 @@ describe '::Base' do
 
         include_examples 'Base::render'
       end
+
+      context 'Given passed object is enumerable but not an array' do
+        let(:blueprint) { blueprint_with_block }
+        let(:additional_object) { OpenStruct.new(obj_hash.merge(id: 2)) }
+        let(:obj) { Set.new([object_with_attributes, additional_object]) }
+
+        it 'should return the expected array of hashes' do
+          should eq('[{"id":1,"position_and_company":"Manager at Procore"},{"id":2,"position_and_company":"Manager at Procore"}]')
+        end
+      end
     end
 
     context 'Inside Rails project' do
@@ -382,6 +392,30 @@ describe '::Base' do
             end
           end
         end
+      end
+
+      context 'Given a collection of objects' do
+        let(:blueprint) do
+          Class.new(Blueprinter::Base) do
+            identifier :id
+            fields :make
+          end
+        end
+        let(:obj) { Vehicle.all }
+        let(:vehicle1) { create(:vehicle) }
+        let(:vehicle2) { create(:vehicle, make: 'Mediocre Car') }
+        let(:vehicle3) { create(:vehicle, make: 'Terrible Car') }
+        let(:result) do
+          vehicles_json = [vehicle1, vehicle2, vehicle3].map do |vehicle|
+            "{\"id\":#{vehicle.id},\"make\":\"#{vehicle.make}\"}"
+          end.join(',')
+          "[#{vehicles_json}]"
+        end
+
+        before { Vehicle.destroy_all }
+        after { Vehicle.destroy_all }
+
+        it('returns the expected result') { should eq(result) }
       end
     end
   end


### PR DESCRIPTION
At my job at @RaiseMe we are using the blueprinter gem in a rails project that uses [Mongoid](https://github.com/mongodb/mongoid) to talk to Mongo rather than using ActiveRecord.  When we want to serialize a collection we always need to call `.to_a` on it to make it serializer properly using blueprinter, for example:

```ruby
UserBlueprinter.render(User.all.to_a)
```

While this is doable, it'd be nice to just be able to do `UserBlueprinter.render(User.all)`, and this PR makes that possible.

It makes it so that anything that is enumerable (other than hashes) gets treated as "array-like".