### PR TITLE
Run tests in CircleCi for ruby versions 2.7 - 3.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,102 @@
+version: 2.1
+
+steps: &steps_spec
+  - checkout
+  - run:
+      name: Installing ruby dependencies
+      command: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle
+  - run:
+      command: bundle exec rake
+  - when:
+      condition: << parameters.benchmark >>
+      steps:
+        - run:
+            command: bundle exec rake benchmarks
+
+jobs:
+  ruby-2_2:
+    parameters:
+      benchmark:
+        type: boolean
+        default: false
+    steps: *steps_spec
+    docker:
+      - image: ruby:2.2
+  ruby-2_3:
+    parameters:
+      benchmark:
+        type: boolean
+        default: true
+    steps: *steps_spec
+    docker:
+      - image: ruby:2.3
+  ruby-2_4:
+    parameters:
+      benchmark:
+        type: boolean
+        default: true
+    steps: *steps_spec
+    docker:
+      - image: ruby:2.4
+  ruby-2_5:
+    parameters:
+      benchmark:
+        type: boolean
+        default: true
+    steps: *steps_spec
+    docker:
+      - image: ruby:2.5
+  ruby-2_6:
+    parameters:
+      benchmark:
+        type: boolean
+        default: true
+    steps: *steps_spec
+    docker:
+      - image: ruby:2.6
+  ruby-2_7:
+    parameters:
+      benchmark:
+        type: boolean
+        default: true
+    steps: *steps_spec
+    docker:
+      - image: ruby:2.7
+  ruby-3_0:
+    parameters:
+      benchmark:
+        type: boolean
+        default: true
+    steps: *steps_spec
+    docker:
+      - image: ruby:3.0
+  ruby-3_1:
+    parameters:
+      benchmark:
+        type: boolean
+        default: true
+    steps: *steps_spec
+    docker:
+      - image: ruby:3.1
+  ruby-3_2:
+    parameters:
+      benchmark:
+        type: boolean
+        default: true
+    steps: *steps_spec
+    docker:
+      - image: ruby:3.2
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - ruby-2_2
+      - ruby-2_3
+      - ruby-2_4
+      - ruby-2_5
+      - ruby-2_6
+      - ruby-2_7
+      - ruby-3_0
+      - ruby-3_1
+      - ruby-3_2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,46 +14,6 @@ steps: &steps_spec
             command: bundle exec rake benchmarks
 
 jobs:
-  ruby-2_2:
-    parameters:
-      benchmark:
-        type: boolean
-        default: false
-    steps: *steps_spec
-    docker:
-      - image: ruby:2.2
-  ruby-2_3:
-    parameters:
-      benchmark:
-        type: boolean
-        default: true
-    steps: *steps_spec
-    docker:
-      - image: ruby:2.3
-  ruby-2_4:
-    parameters:
-      benchmark:
-        type: boolean
-        default: true
-    steps: *steps_spec
-    docker:
-      - image: ruby:2.4
-  ruby-2_5:
-    parameters:
-      benchmark:
-        type: boolean
-        default: true
-    steps: *steps_spec
-    docker:
-      - image: ruby:2.5
-  ruby-2_6:
-    parameters:
-      benchmark:
-        type: boolean
-        default: true
-    steps: *steps_spec
-    docker:
-      - image: ruby:2.6
   ruby-2_7:
     parameters:
       benchmark:
@@ -91,11 +51,6 @@ workflows:
   version: 2
   test:
     jobs:
-      - ruby-2_2
-      - ruby-2_3
-      - ruby-2_4
-      - ruby-2_5
-      - ruby-2_6
       - ruby-2_7
       - ruby-3_0
       - ruby-3_1

--- a/blueprinter.gemspec
+++ b/blueprinter.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "CHANGELOG.md", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.required_ruby_version = '>= 2.6.9'
+  s.required_ruby_version = '>= 2.2.2'
 
   s.add_development_dependency "factory_bot", "~> 6.2"
   s.add_development_dependency "oj", "~> 3.13"

--- a/blueprinter.gemspec
+++ b/blueprinter.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "CHANGELOG.md", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.required_ruby_version = '>= 2.2.2'
+  s.required_ruby_version = '>= 2.6.9'
 
   s.add_development_dependency "factory_bot", "~> 6.2"
   s.add_development_dependency "oj", "~> 3.13"


### PR DESCRIPTION
This brings back the circleci tests which can give us some confidence in the gem working in all the expected ruby versions.

I removed the part of the original configuration that dealt with releasing the gem automatically and also removed the ruby versions that no longer work with this gem (everything before 2.6.9).

Here are what the successful tests look like:
![image](https://user-images.githubusercontent.com/6495028/212402097-d257de9e-5254-476d-a257-6d805ee3cefa.png)

Running the tests in CircleCI is free.  You just need to go to app.circleci.com to set up the project for this repo.  I could do it for my fork that I have control of, but not for the blueprinter-ruby/blueprinter version of the repository.