### PR TITLE
Add gem version badge to README pointed at new gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Gem Version](https://badge.fury.io/rb/blueprinter-rb.svg)](https://badge.fury.io/rb/blueprinter-rb)
+
 # Blueprinter
 Blueprinter is a JSON Object Presenter for Ruby that takes business objects and breaks them down into simple hashes and serializes them to JSON. It can be used in Rails in place of other serializers (like JBuilder or ActiveModelSerializers). It is designed to be simple, direct, and performant.
 


### PR DESCRIPTION
Thought it'd be nice to have this back, but pointed at the correct gem.