### PR TITLE
Removed deprecations on `Blueprinter::Field` callables and `EmptyTypes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.0 - 2023/06/13
+* 💅 [ENHANCEMENT] if/:unless procs with two arguments and invalid empty type deprecations are now removed
+
 ## 1.1.2 - 2023/02/06
 * 💅 [ENHANCEMENT] Introduce rubocop and add a Github action for it
 

--- a/lib/blueprinter/empty_types.rb
+++ b/lib/blueprinter/empty_types.rb
@@ -22,11 +22,6 @@ module Blueprinter
         value.is_a?(Hash) && value.empty?
       when Blueprinter::EMPTY_STRING
         value.to_s == ''
-      else
-        Blueprinter::Deprecation.report(
-          "Invalid empty type '#{empty_type}' received. Blueprinter will raise an error in the next major version." \
-          'Must be one of [nil, Blueprinter::EMPTY_COLLECTION, Blueprinter::EMPTY_HASH, Blueprinter::EMPTY_STRING]'
-        )
       end
     end
   end

--- a/lib/blueprinter/field.rb
+++ b/lib/blueprinter/field.rb
@@ -38,16 +38,6 @@ module Blueprinter
     end
 
     def callable_from(condition)
-      callable = old_callable_from(condition)
-
-      if callable && callable.arity == 2
-        ->(_field_name, obj, options) { callable.call(obj, options) }
-      else
-        callable
-      end
-    end
-
-    def old_callable_from(condition)
       config = Blueprinter.configuration
 
       # Use field-level callable, or when not defined, try global callable

--- a/lib/blueprinter/field.rb
+++ b/lib/blueprinter/field.rb
@@ -41,7 +41,6 @@ module Blueprinter
       callable = old_callable_from(condition)
 
       if callable && callable.arity == 2
-        Blueprinter::Deprecation.report("`:#{condition}` conditions now expects 3 arguments instead of 2.")
         ->(_field_name, obj, options) { callable.call(obj, options) }
       else
         callable

--- a/lib/blueprinter/version.rb
+++ b/lib/blueprinter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Blueprinter
-  VERSION = '1.1.2'
+  VERSION = '1.2.0'
 end

--- a/spec/integrations/shared/base_render_examples.rb
+++ b/spec/integrations/shared/base_render_examples.rb
@@ -174,17 +174,18 @@ shared_examples 'Base::render' do
   end
 
   context 'Given default_if option is invalid' do
+    before do
+      obj[:first_name] = ""
+    end
+
+    let(:result) { %({"first_name":"","id":#{obj_id}}) }
     let(:blueprint) do
       Class.new(Blueprinter::Base) do
         field :id
         field :first_name, default_if: "INVALID_EMPTY_TYPE", default: "Unknown"
       end
     end
-    it('reports a deprecation message') do
-      allow(Blueprinter::Deprecation).to receive(:report)
-      blueprint.render(obj)
-      expect(Blueprinter::Deprecation).to have_received(:report).with(match(/Invalid empty type '.*' received. Blueprinter will raise an error in the next major version./))
-    end
+    it('does not use the default value') { should eq(result) }
   end
 
   context "Given blueprint has ::field with nil value" do
@@ -257,8 +258,9 @@ shared_examples 'Base::render' do
 
   context 'Given blueprint has ::field with a conditional argument' do
     context 'Given conditional proc has deprecated two argument signature' do
-      let(:if_proc) { ->(_obj, _local_opts) { true } }
-      let(:unless_proc) { ->(_obj, _local_opts) { true } }
+      let(:result_with_first_name) do
+        %({"first_name":"Meg","id":#{obj_id}})
+      end
 
       let(:blueprint) do
         Class.new(Blueprinter::Base) do
@@ -268,11 +270,8 @@ shared_examples 'Base::render' do
         end
       end
 
-      it('reports a deprecation warning') do
-        allow(Blueprinter::Deprecation).to receive(:report)
-        blueprint.render(obj)
-        expect(Blueprinter::Deprecation).to have_received(:report).with("`:if` conditions now expects 3 arguments instead of 2.")
-        expect(Blueprinter::Deprecation).to have_received(:report).with("`:unless` conditions now expects 3 arguments instead of 2.")
+      it 'serializes the conditional field' do
+        should eq(result_with_first_name)
       end
     end
 

--- a/spec/integrations/shared/base_render_examples.rb
+++ b/spec/integrations/shared/base_render_examples.rb
@@ -257,24 +257,6 @@ shared_examples 'Base::render' do
   end
 
   context 'Given blueprint has ::field with a conditional argument' do
-    context 'Given conditional proc has deprecated two argument signature' do
-      let(:result_with_first_name) do
-        %({"first_name":"Meg","id":#{obj_id}})
-      end
-
-      let(:blueprint) do
-        Class.new(Blueprinter::Base) do
-          field :id
-          field :first_name, if: ->(_obj, _local_opts) { true }
-          field :last_name, unless: ->(_obj, _local_opts) { true }
-        end
-      end
-
-      it 'serializes the conditional field' do
-        should eq(result_with_first_name)
-      end
-    end
-
     context 'Given conditional proc has three argument signature' do
       variants = %i[proc method].product([true, false])
 


### PR DESCRIPTION
Issue: https://github.com/blueprinter-ruby/blueprinter/issues/11

Removed deprecations on `Blueprinter::Field` callables and `EmptyTypes`
Modified specs